### PR TITLE
Separate generate_values() tests into valid and invalid configs

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: mark test as slow.

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -155,8 +155,8 @@ def test_file_creation(script_runner):
         assert len(result.stderr) == 0 # No output in error output stream
 
 # Test successful run when generating plots (the plots themselves are not tested)
-@patch("uavnoma.command_line.plt") # Avoid getting stuck when calling plot.show()
-def test_success_plot(plt, script_runner):
+@patch("uavnoma.command_line.plt.show") # Avoid getting stuck when calling plot.show()
+def test_success_plot(show, script_runner):
     result = script_runner.run(script_name, '--plot')
     assert result.success          # Successful run
     assert result.returncode == 0  # Code 0 means successful run

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -12,7 +12,7 @@ script_name = 'uavnoma'
 
 # Valid parameters, for testing one or two of them at a time
 # Here we use both short and long forms
-data_individual_params_valid = [
+data_params_valid_individual = [
     (['-h']),     # Request for help is a valid input
     (['--help']), # Request for help is a valid input
     ([]),         # No parameters is valid input
@@ -35,7 +35,7 @@ data_individual_params_valid = [
 
 # Invalid parameters, for testing one or two of them at a time
 # No need to repeat both short and long forms, use only one of them
-data_individual_params_invalid = [
+data_params_invalid_individual = [
     (['-p', str(-1.0)]),
     (['-l', str(-2.0)]),
     (['-s', str(10), '-f', str(20.0)]),
@@ -81,7 +81,7 @@ snr_samples_range = [round(x) for x in np.linspace(10, 40, num=num_values)]
 seed_range = [123] # Use just one seed, otherwise it takes too long
 
 # Create valid combinations of parameters
-data_combination_params_valid = [
+data_params_valid_combination = [
     (
         '-s', str(s), '-p', str(p), '-f', str(f), '-l', str(l), '-r', str(r),
         '-ur', str(ur), '-uh', str(uh), '-t1', str(t1), '-t2', str(t2),
@@ -108,11 +108,20 @@ data_combination_params_valid = [
     for seed in seed_range
 ]
 
-# Test valid parameters (individual + combinations)
+# Test valid individual parameters
+@pytest.mark.parametrize('params', data_params_valid_individual)
+def test_success_individual(script_runner, params):
+    subtest_success(script_runner, params)
+
 # This is a slow test, to avoid running it use `pytest -m "not slow"`
 @pytest.mark.slow
-@pytest.mark.parametrize('params', data_individual_params_valid + data_combination_params_valid)
-def test_success(script_runner, params):
+@pytest.mark.parametrize('params', data_params_valid_combination)
+def test_success_combination(script_runner, params):
+    subtest_success(script_runner, params)
+
+# This function is not directly a test; it will be called by other actual test
+# functions
+def subtest_success(script_runner, params):
     result = script_runner.run(script_name, *params)
     assert result.success          # Successful run
     assert result.returncode == 0  # Code 0 means successful run
@@ -120,7 +129,7 @@ def test_success(script_runner, params):
     assert len(result.stderr) == 0 # No output in error output stream
 
 # Test invalid individual parameters
-@pytest.mark.parametrize('params', data_individual_params_invalid)
+@pytest.mark.parametrize('params', data_params_invalid_individual)
 def test_failure(script_runner, params):
     result = script_runner.run(script_name, *params)
     assert not result.success     # Unsuccessful run

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -79,7 +79,8 @@ snr_min_range = np.linspace(10.0, 15.0, num=num_values)
 snr_max_range = np.linspace(30.0, 80.0, num=num_values)
 snr_samples_range = [round(x) for x in np.linspace(10, 40, num=num_values)]
 seed_range = [123] # Use just one seed, otherwise it takes too long
-""" 
+
+# Create valid combinations of parameters
 data_combination_params_valid = [
     (
         '-s', str(s), '-p', str(p), '-f', str(f), '-l', str(l), '-r', str(r),
@@ -108,13 +109,15 @@ data_combination_params_valid = [
 ]
 
 # Test valid parameters (individual + combinations)
+# This is a slow test, to avoid running it use `pytest -m "not slow"`
+@pytest.mark.slow
 @pytest.mark.parametrize('params', data_individual_params_valid + data_combination_params_valid)
 def test_success(script_runner, params):
     result = script_runner.run(script_name, *params)
     assert result.success          # Successful run
     assert result.returncode == 0  # Code 0 means successful run
     assert len(result.stdout) > 0  # Measurable output in standard output stream
-    assert len(result.stderr) == 0 # No output in error output stream """
+    assert len(result.stderr) == 0 # No output in error output stream
 
 # Test invalid individual parameters
 @pytest.mark.parametrize('params', data_individual_params_invalid)

--- a/tests/test_generate_values.py
+++ b/tests/test_generate_values.py
@@ -2,49 +2,80 @@ import pytest
 import numpy as np
 from uavnoma.generate_values import *
 
+#
+# Valid and invalid parameters for testing the generate_values module
+#
 
-# Valid and invalid parameters for testing the generate_values of uavnoma package
-data_parameter_position_user = [
-    ([2, 10]), # Valid # number_user, radius_user 
-    ([4, 6]),  # Invalid
+data_parameter_position_user_valid = [
+    # number_user, radius_user
+    ([2, 10]), # Valid
     ([2, 18]), # Valid
+]
+
+data_parameter_position_user_invalid = [
+    # number_user, radius_user
+    ([4, 6]),  # Invalid
     ([2, -1]), # Invalid
 ]
 
-data_parameter_position_uav = [
-    ([1, 2, 20]), # Valid # number_uav, radius_uav, height_uav
-    ([1, 6, -2]), # Invalid
+data_parameter_position_uav_valid = [
+    # number_uav, radius_uav, height_uav
+    ([1, 2, 20]), # Valid
     ([1, 4, 25]), # Valid
-    ([1, -1, 80]),# Invalid  
 ]
 
-data_parameter_rician_fading = [
-    ([15, 1]),  # Valid # rician_factor, power_los
+data_parameter_position_uav_invalid = [
+    # number_uav, radius_uav, height_uav
+    ([1, 6, -2]), # Invalid
+    ([1, 4, 25]), # Valid
+]
+
+data_parameter_rician_fading_valid = [
+    # rician_factor, power_los
+    ([15, 1]),  # Valid
     ([18 , 2]),  # Valid
+]
+
+data_parameter_rician_fading_invalid = [
+    # rician_factor, power_los
     ([-2, 15]), # Invalid
     ([26, -1]), # Invalid
 ]
 
-data_parameter_generate_channel = [
-    ([2, 10.0, 6.0, 2.0, 4.0, 35.0, 2.0, 15.0, 1.0]),  # Valid # number_user, axis x user position, axis y user position, axis x uav position, axis y uav position, uav mean height, path_loss, rician_factor, power_los
-    ([4, 2.0, 15.0, 4.0, 2.0, 20.0, 2.2, 18.0, 2.0]),  # Invalid
+data_parameter_generate_channel_valid = [
+    # number_user, axis x user position, axis y user position, axis x uav position, axis y uav position, uav mean height, path_loss, rician_factor, power_los
+    ([2, 10.0, 6.0, 2.0, 4.0, 35.0, 2.0, 15.0, 1.0]),  # Valid
     ([2, 10.0, 10.0, 2.0, 3.0, 40.0, 2.0, 16.0, 2.0]), # Valid
-    ([2, 8.0, 15.0, 2.0, 3.0, 40.0, 8.0, 3.0, 4.0]),   # Invalid
-] 
+]
 
-# Test user position
-@pytest.mark.parametrize("number_users, radius_user", data_parameter_position_user)
-def test_position_user(number_users, radius_user): 
+data_parameter_generate_channel_invalid = [
+    # number_user, axis x user position, axis y user position, axis x uav position, axis y uav position, uav mean height, path_loss, rician_factor, power_los
+    ([4, 2.0, 15.0, 4.0, 2.0, 20.0, 2.2, 18.0, 2.0]),  # Invalid
+    ([2, 8.0, 15.0, 2.0, 3.0, 40.0, 8.0, 3.0, 4.0]),   # Invalid
+]
+
+#
+# Tests for generate_values module
+#
+
+# Test user position (valid parameters)
+@pytest.mark.parametrize("number_users, radius_user", data_parameter_position_user_valid)
+def test_position_user_valid(number_users, radius_user):
     assert number_users == 2
     x_u, y_u = random_position_users(number_users, radius_user)
     assert x_u.all() <= radius_user
     assert y_u.all() <= radius_user
 
+# Test user position (invalid parameters)
+@pytest.mark.parametrize("number_users, radius_user", data_parameter_position_user_invalid)
+def test_position_user_invalid(number_users, radius_user):
+    # Although the parameters are invalid for the simulation as a whole, this
+    # function will work its math without throwing exceptions
+    random_position_users(number_users, radius_user)
 
-
-# Test uav position
-@pytest.mark.parametrize("number_uav, radius_uav, height_uav", data_parameter_position_uav)
-def test_position_uav(number_uav, radius_uav, height_uav):
+# Test uav position (valid parameters)
+@pytest.mark.parametrize("number_uav, radius_uav, height_uav", data_parameter_position_uav_valid)
+def test_position_uav_valid(number_uav, radius_uav, height_uav):
     assert number_uav == 1
     x_u, y_u, z_u = random_position_uav(number_uav, radius_uav, height_uav)
     assert x_u <= radius_uav
@@ -53,24 +84,49 @@ def test_position_uav(number_uav, radius_uav, height_uav):
         height_uav - 5 <= z_u <= height_uav + 5
     )
 
+# Test uav position (invalid parameters)
+@pytest.mark.parametrize("number_uav, radius_uav, height_uav", data_parameter_position_uav_invalid)
+def test_position_uav_valid(number_uav, radius_uav, height_uav):
+    # Although the parameters are invalid for the simulation as a whole, this
+    # function will work its math without throwing exceptions
+    random_position_uav(number_uav, radius_uav, height_uav)
 
-# Test rician fading
-@pytest.mark.parametrize("rician_factor, power_los", data_parameter_rician_fading)
-def test_rician_parameters(rician_factor, power_los):
+# Test rician fading (valid parameters)
+@pytest.mark.parametrize("rician_factor, power_los", data_parameter_rician_fading_valid)
+def test_rician_parameters_valid(rician_factor, power_los):
     # Fading modeled by Rician distribution
     s, sigma = fading_rician(rician_factor, power_los)
     assert s > 0 and s <=1.5  # Non-negative
     assert sigma > 0 and sigma <= 1.5  # Non-negative
-    return s, sigma
 
-# Test generate channel
-@pytest.mark.parametrize("number_user, x_u, y_u, x_r, y_r, uav_height_mean, path_loss, rician_factor, power_los", data_parameter_generate_channel)
-def test_channel_gain(number_user, x_u, y_u, x_r, y_r, uav_height_mean, path_loss, rician_factor, power_los):
-    s, sigma = fading_rician(rician_factor, power_los)  # Fading modeled by Rician distribution 
+# Test rician fading (invalid parameters)
+@pytest.mark.parametrize("rician_factor, power_los", data_parameter_rician_fading_invalid)
+def test_rician_parameters_invalid(rician_factor, power_los):
+    # This function will throw runtime warnings due to invalid values passed to
+    # NumPy's sqrt() function
+    with pytest.warns(RuntimeWarning):
+        fading_rician(rician_factor, power_los)
+
+# Test generate channel (valid parameters)
+@pytest.mark.parametrize("number_user, x_u, y_u, x_r, y_r, uav_height_mean, path_loss, rician_factor, power_los", data_parameter_generate_channel_valid)
+def test_channel_gain_valid(number_user, x_u, y_u, x_r, y_r, uav_height_mean, path_loss, rician_factor, power_los):
+    # TODO We should no depend on fading_rician() to get s and sigma; we should
+    # specify s and sigma directly since we're only testing generate_channel()
+    # in isolation
+    s, sigma = fading_rician(rician_factor, power_los)  # Fading modeled by Rician distribution
     channel_gain_primary, channel_gain_secondary = generate_channel(
         s, sigma, number_user, x_u, y_u, x_r, y_r, uav_height_mean, path_loss
     )
     assert channel_gain_primary >= 0  # Non-negative
     assert channel_gain_secondary >= 0  # Non-negative
-    assert channel_gain_primary <= channel_gain_secondary 
-    return channel_gain_primary, channel_gain_secondary 
+    assert channel_gain_primary <= channel_gain_secondary
+
+# Test generate channel (invalid parameters)
+@pytest.mark.parametrize("number_user, x_u, y_u, x_r, y_r, uav_height_mean, path_loss, rician_factor, power_los", data_parameter_generate_channel_invalid)
+def test_channel_gain_invalid(number_user, x_u, y_u, x_r, y_r, uav_height_mean, path_loss, rician_factor, power_los):
+    # TODO We should no depend on fading_rician() to get s and sigma; we should
+    # specify s and sigma directly since we're only testing generate_channel()
+    # in isolation
+    s, sigma = fading_rician(rician_factor, power_los)  # Fading modeled by Rician distribution
+    # TODO What to expect here?
+    generate_channel(s, sigma, number_user, x_u, y_u, x_r, y_r, uav_height_mean, path_loss)


### PR DESCRIPTION
- Separate `generate_values()` tests into valid and invalid configs
- Mark slow tests as slow, avoid running them with `-m "not slow"`
- Script plot test: only mock `show()` method, not all plot functions